### PR TITLE
feat(dashboard): implement work schedule and exceptions management page

### DIFF
--- a/ora-fixa/package-lock.json
+++ b/ora-fixa/package-lock.json
@@ -6389,20 +6389,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/ora-fixa/src/app.d.ts
+++ b/ora-fixa/src/app.d.ts
@@ -9,11 +9,10 @@ declare global {
 			safeGetSession: () => Promise<{ session: Session | null; user: User | null }>;
 			session: Session | null;
 			user: User | null;
-			isAdmin: boolean | false;
+			isAdmin: Boolean | null;
 		}
 		interface PageData {
 			session: Session | null;
-			isAdmin: boolean | false;
 		}
 	}
 }

--- a/ora-fixa/src/lib/components/appointments-table.svelte
+++ b/ora-fixa/src/lib/components/appointments-table.svelte
@@ -311,9 +311,14 @@
 		</Table.Root>
 	</div>
 	<div class="flex w-full items-center justify-between p-3">
-		<span class="mt-4 text-end text-sm text-stone-500"
+		<div class='flex-col flex'>
+			<span class="mt-4 text-end text-sm text-stone-500"
 			>{table.getFilteredRowModel().rows.length} din {table.getState().pagination.pageSize} programări.
 		</span>
+		<span class='text-sm text-stone-500'>
+			Pagina {currentPage}.
+		</span>
+	</div>
 		<div class="space-x-1">
 			<Button
 				variant="outline"

--- a/ora-fixa/src/lib/schemas.ts
+++ b/ora-fixa/src/lib/schemas.ts
@@ -81,3 +81,10 @@ export const updateStatusSchema = z.object({
     appointmentId: z.string(),
     status: z.string()
 })
+
+export const scheduleOverrideSchema = z.object({
+	date: z.string(),
+	startTime: z.string(),
+	endTime: z.string(),
+	isActive: z.boolean()
+})

--- a/ora-fixa/src/routes/(admin)/admin/dashboard/+page.server.ts
+++ b/ora-fixa/src/routes/(admin)/admin/dashboard/+page.server.ts
@@ -10,7 +10,6 @@ export const load: PageServerLoad = async ({ locals: { supabase, session }, url 
 		dateParam && !isNaN(Date.parse(dateParam))
 			? new Date(dateParam).toISOString().split('T')[0]
 			: new Date().toISOString().split('T')[0];
-	// REVIEW LATER
 
 	const form = await superValidate(zod(walkInSchema));
 
@@ -143,7 +142,7 @@ export const actions: Actions = {
 
 		return { success: true };
 	},
-	addWalkInAppointment: async ({ request, locals: { supabase, session } }) => {
+	addWalkInAppointment: async ({ request, locals: { supabase, session, isAdmin} }) => {
 		const form = await superValidate(request, zod(walkInSchema));
 		if (!form.valid) {
 			console.log(form);
@@ -153,13 +152,7 @@ export const actions: Actions = {
 		const startTime = new Date(`${form.data.date.split('T')[0]}T${form.data.time}:00.000Z`);
 		const endTime = new Date(startTime.getTime() + form.data.duration * 60 * 1000);
 
-		const { data: profile } = await supabase
-			.from('profiles')
-			.select('is_admin')
-			.eq('id', session?.user.id)
-			.single();
-
-		if (!profile.is_admin) {
+		if (!isAdmin) {
 			return fail(401, { message: 'Neautorizat.' });
 		}
 

--- a/ora-fixa/src/routes/(admin)/admin/program/+page.server.ts
+++ b/ora-fixa/src/routes/(admin)/admin/program/+page.server.ts
@@ -1,0 +1,76 @@
+import { fail, message } from 'sveltekit-superforms';
+import {superValidate} from 'sveltekit-superforms/server'
+import type { PageServerLoad, Actions } from './$types';
+import { zod } from 'sveltekit-superforms/adapters';
+import { scheduleOverrideSchema } from '$lib/schemas';
+import { Day } from '$lib/components/ui/calendar';
+
+export const load: PageServerLoad = async ({ locals: { supabase, session } }) => {
+	const { data: workSchedules } = await supabase
+		.from('work_schedules')
+		.select('*')
+		.order('day_of_week');
+	const { data: scheduleOverrides } = await supabase.from('schedule_overrides').select('*');
+
+	const overrideForm = await superValidate(zod(scheduleOverrideSchema));
+
+	return {
+		workSchedules,
+		scheduleOverrides,
+		overrideForm,
+		session
+	};
+};
+
+export const actions: Actions = {
+    updateWeeklySchedule: async({request, locals: {supabase, isAdmin}}) => {
+		const formData = await request.formData()
+		const schedulesToSave = []
+
+		for(let i = 1; i <= 7; i++){
+			const isActive = formData.get(`is_active_${i}`)
+			schedulesToSave.push({
+				day_of_week: i,
+				is_active: isActive ?? false,
+				start_time: isActive && formData.get(`start_time_${i}`) ? formData.get(`start_time_${i}`) : '12:00:00',
+				end_time: isActive  && formData.get(`end_time_${i}`) ? formData.get(`end_time_${i}`) : '12:00:00',
+			})
+		}
+
+		console.log(schedulesToSave)
+
+		const {error} = await supabase.from("work_schedules").upsert(schedulesToSave, {onConflict: 'day_of_week'})
+
+		console.log(error)
+
+		if (error) return fail(500, { message: 'Eroare la salvarea programului standard.' });
+		
+		return {success: true}
+    },
+	setScheduleOverride: async({request, locals: {supabase, isAdmin}}) => {
+		if(!isAdmin){
+			return
+		}
+		const form = await superValidate(request, zod(scheduleOverrideSchema))
+
+				if (!form.valid) return fail(400, { form });
+
+			const {date, isActive, startTime, endTime} = form.data
+
+			const {error} = await supabase.from('schedule_overrides').upsert(
+				{
+					date: date,
+					is_active: isActive,
+					start_time: startTime || '12:00:00',
+					end_time: endTime || '12:00:00',
+				}
+			,{onConflict: 'date'})
+
+			console.log(error)
+
+			if (error) return message(form, 'A apărut o eroare la salvarea excepției.', { status: 500 });
+
+			return message(form, 'Excepția a fost salvată cu succes!');
+
+	}
+}

--- a/ora-fixa/src/routes/(admin)/admin/program/+page.svelte
+++ b/ora-fixa/src/routes/(admin)/admin/program/+page.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { enhance } from '$app/forms';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import { getLocalTimeZone, today } from '@internationalized/date';
+	import { Calendar } from '$lib/components/ui/calendar/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { toast } from 'svelte-sonner';
+	import { invalidateAll } from '$app/navigation';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
+	import { type DateValue, DateFormatter } from '@internationalized/date';
+	import { cn } from '$lib/utils.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import { superForm } from 'sveltekit-superforms';
+	import { Save } from 'lucide-svelte';
+
+	let { data } = $props();
+
+	let dateValue: DateValue | undefined = $state();
+
+	const df = new DateFormatter('ro-RO', {
+		dateStyle: 'long'
+	});
+
+	const {
+		form,
+		errors,
+		enhance: formEnhance,
+		submitting: isSubmittingOverride
+	} = superForm(data.overrideForm, {
+		id: 'override-form',
+				onResult: ({ result }) => {
+			if (result.type === 'success') {
+				toast.success('Succes!', { description: result.data?.form.message });
+				dateValue = undefined;
+				invalidateAll();
+			}
+		}
+	});
+
+	let schedules = $state(
+		[...Array(7)].map((_, i) => {
+			const dayOfWeek = i + 1;
+			const existingSchedule = data.workSchedules?.find((s) => s.day_of_week === dayOfWeek);
+			return (
+				existingSchedule || {
+					day_of_week: dayOfWeek,
+					is_active: false,
+					start_time: '09:00',
+					end_time: '17:00'
+				}
+			);
+		})
+	);
+
+	const daysOfWeek = [
+		{ id: 1, name: 'Luni' },
+		{ id: 2, name: 'Marți' },
+		{ id: 3, name: 'Miercuri' },
+		{ id: 4, name: 'Joi' },
+		{ id: 5, name: 'Vineri' },
+		{ id: 6, name: 'Sâmbătă' },
+		{ id: 7, name: 'Duminică' }
+	];
+</script>
+
+<div class="flex flex-1 flex-col">
+	<div class="@container/main flex flex-1 flex-col gap-2">
+		<div class="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+			<div class="px-4 lg:px-6">
+				<h1 class="mb-6 text-3xl font-medium">Program de lucru</h1>
+				<div class="grid grid-cols-1 items-start gap-8 md:grid-cols-2">
+					<Card.Root>
+						<Card.Header>
+							<Card.Title>Program Standard</Card.Title>
+							<Card.Description
+								>Setează programul de lucru recurent pentru fiecare zi.</Card.Description
+							>
+						</Card.Header>
+						<form
+							action="?/updateWeeklySchedule"
+							method="POST"
+							use:enhance={() => {
+								return async ({ result }) => {
+									if (result.type === 'success') {
+										toast.success('Programul a fost modificat cu succes.');
+										await invalidateAll();
+									} else {
+										toast.error('Eroare:', {
+											description: 'Programul nu a putut fi modificat ca succes.'
+										});
+									}
+								};
+							}}
+						>
+							<Card.Content class="space-y-4">
+								{#each schedules as schedule, i (schedule.day_of_week)}
+									<Label>{daysOfWeek.find((day) => day.id === schedule.day_of_week)?.name}</Label>
+									<div class="flex w-full flex-row items-center space-x-2">
+										<Checkbox
+											bind:checked={schedule.is_active}
+											name={`is_active_${schedule.day_of_week}`}
+										/>
+										<div class="grid w-full grid-cols-2 justify-around gap-2">
+											<Input
+												type="time"
+												name={`start_time_${schedule.day_of_week}`}
+												value={schedule.start_time}
+												class="w-full"
+												disabled={!schedule.is_active}
+											/>
+
+											<Input
+												type="time"
+												name={`end_time_${schedule.day_of_week}`}
+												value={schedule.end_time}
+												class="w-full"
+												disabled={!schedule.is_active}
+											/>
+										</div>
+									</div>
+								{/each}
+							</Card.Content>
+							<Card.Footer>
+								<Button class="mt-4" type="submit"><Save class='w-5 h-5' />Salvează Programul</Button>
+							</Card.Footer>
+						</form>
+					</Card.Root>
+					<Card.Root>
+						<Card.Header>
+							<Card.Title>Program Personalizat</Card.Title>
+							<Card.Description
+								>Setează programul de lucru personalizat pentru fiecare zi.</Card.Description
+							>
+						</Card.Header>
+						<Card.Content>
+							<Popover.Root>
+								<Popover.Trigger class="w-full">
+									{#snippet child({ props })}
+										<Button
+											variant="outline"
+											class={cn(
+												'justify-start text-left font-normal',
+												!dateValue && 'text-muted-foreground'
+											)}
+											{...props}
+										>
+											<CalendarIcon class="mr-2 size-4" />
+											{dateValue
+												? df.format(dateValue.toDate(getLocalTimeZone()))
+												: 'Selecteaza o data.'}
+										</Button>
+									{/snippet}
+								</Popover.Trigger>
+								<Popover.Content class="w-auto p-0">
+									<Calendar locale='ro' bind:value={dateValue} minValue={today(getLocalTimeZone())} disableDaysOutsideMonth={true} type="single" initialFocus 								onValueChange={() => {
+									if (dateValue) {
+										$form.date = dateValue.toDate(getLocalTimeZone()).toISOString();
+									}
+								}}/>
+								</Popover.Content>
+							</Popover.Root>
+							{#if dateValue}
+								<Separator class="mt-4" />
+								<form
+									action="?/setScheduleOverride"
+									method="POST"
+									use:formEnhance
+								>
+									<div class="space-y-4 mt-4">
+										<input type="hidden" name="date" bind:value={$form.date} />
+										<div class="flex items-center space-x-2">
+											<Checkbox
+												id="is_active_override"
+												name="isActive"
+												bind:checked={$form.isActive}
+											/>
+											<Label for="is_active_override">Zi lucrătoare</Label>
+										</div>
+										{#if $form.isActive}
+											<div class="flex items-center gap-4">
+												<div class="w-full space-y-2">
+													<Label for="start_time_override">Ora Început</Label>
+													<Input
+														id="start_time_override"
+														name="startTime"
+														bind:value={$form.startTime}
+														type="time"
+													/>
+												</div>
+												<div class="w-full space-y-2">
+													<Label for="end_time_override">Ora Început</Label>
+													<Input
+														id="end_time_override"
+														name="endTime"
+														bind:value={$form.endTime}
+														type="time"
+													/>
+												</div>
+											</div>
+										{/if}
+										<Button disabled={$isSubmittingOverride} type='submit'><Save class='w-5 h-5' /> Salvează Excepția</Button>
+									</div>
+								</form>
+							{/if}
+						</Card.Content>
+					</Card.Root>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
### Context
Previously, the barbershop's working hours were static and could not be modified without code changes. This created a significant operational bottleneck for managing holidays, vacations, or special events. This feature introduces a dedicated admin page to give the business owner full, dynamic control over the shop's availability, directly impacting the accuracy of the public booking module.

### Implementation

- Created a new protected route at /admin/schedule.
- Developed a UI for managing the standard weekly work schedule (Monday-Sunday), allowing the admin to set opening/closing times for each day.s
- Implemented a separate section for adding, viewing, and deleting specific date exceptions (e.g., setting a specific date as 'Closed' for a holiday or defining custom hours for an event).
- Added two new SvelteKit form actions (?/updateSchedule and ?/manageException) with full server-side validation using Superforms.

### Verification
    

- [x]  As an admin, navigate to /admin/schedule and set the standard weekly hours. Save and confirm the data persists.
- [x]  Add a new exception for a specific date (e.g., set next Monday as 'Closed').
- [x] Go to the public booking page and select that specific date (next Monday). Verify that no time slots are available for booking.
- [x] Select a regular working day and verify the available slots correctly reflect the standard schedule you have set.
- [x] (Security) As a non-admin user, attempt to access /admin/schedule and verify you are redirected.